### PR TITLE
Revert "Make 'dkms add' step "idempotent""

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -28,7 +28,6 @@
 
 - name: Add module via dkms
   command: dkms add -m ixgbevf -v "{{ ixgbevf_version }}"
-  ignore_errors: yes # 'dkms add' isn't idempotent - so we just skip errors
 
 - name: Build module via dkms
   command: dkms build -m ixgbevf -v "{{ ixgbevf_version }}"


### PR DESCRIPTION
Reverts atlassian/ansible-ixgbevf#1

@samcday I went back and looked at this again we are handling idempotency with a include/when statement for the whole install.yml. The dkms add command will give us a rc = 3 if the module already exists so I will bail early if we detect that but otherwise I think any errors would be valid errors? 
