### PR TITLE
Remove UTS_UBUNTU_RELEASE_ABI check in kcompat.h

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,6 +22,10 @@
              dest=/usr/src/
              copy=no
 
+# https://stackoverflow.com/a/44833347/1589726
+- name: Remove UTS_UBUNTU_RELEASE_ABI check in kcompat.h
+  command: sed -i 's/#if UTS_UBUNTU_RELEASE_ABI > 255/#if UTS_UBUNTU_RELEASE_ABI > 99255/' /usr/src/ixgbevf-{{ ixgbevf_version }}/src/kcompat.h
+
 - name: Install dkms.conf
   template: src=dkms.conf
             dest="/usr/src/ixgbevf-{{ ixgbevf_version }}/dkms.conf"


### PR DESCRIPTION
I was running into a problem where the ixgbevf module would not build on my AWS server.
The error log said:
> #error UTS_UBUNTU_RELEASE_ABI is too large

I found this stackoverflow link which seems to cover why this happens [https://stackoverflow.com/a/44833347/1589726](https://stackoverflow.com/a/44833347/1589726)

It seems an ABS check in the kcompat.h file of the ixgbevf module is incompatible with the AWS kernel versioning scheme. The stackoverflow comment mentions they have notified AWS. AWS says that the check is wrong rather than their kernel versioning scheme.

Hopefully this conditional ABS check will be removed from  kcompat.h but for now I've added in a task to remove it. With this in place I can successfully install ixgbevf.